### PR TITLE
Target sample at Framework v4.6.1; 

### DIFF
--- a/samples/Console/TrueMythConsole.csproj
+++ b/samples/Console/TrueMythConsole.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TrueMythConsole</RootNamespace>
     <AssemblyName>TrueMythConsole</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
This appeases netstandard2.0 demands, although the compiler complains about assembly binding.  