### PR TITLE
IComparable/IComparable<T> implementation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,9 +26,6 @@ jobs:
       inputs:
         version: 2.1.500
 
-    - powershell: echo "##vso[task.setVariable variable=releaseTag;isOutput=true]$(git tag --points-at HEAD | sls '^v([0-9]+\.[0-9]+\.[0-9]+(\-.*)?)$' |% { $_.Matches[0].Groups[1] } | select -last 1 -ExpandProperty Value)"
-      displayName: "Set Release Version"
-
     - task: NuGetToolInstaller@0
       displayName: "Install NuGet"
 
@@ -69,7 +66,7 @@ jobs:
         codeCoverageEnabled: true
 
     - task: DotNetCoreCLI@2
-      condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'), not(variables['releaseTag']))
+      condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master')))
       displayName: 'NuGet Pack (CI)'
       inputs:
         command: pack
@@ -80,19 +77,6 @@ jobs:
         requestedPatchVersion: '$(patchVersion)'
         arguments: '--include-symbols'
       env:
-        DOTNET_CLI_TELEMETRY_OPTOUT: true
-
-    - task: DotNetCoreCLI@2
-      condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'), variables['releaseTag'])
-      displayName: 'NuGet Pack (Release: $(releaseTag))'
-      inputs:
-        command: pack
-        packagesToPack: 'src/TrueMyth/TrueMyth.csproj'
-        versioningScheme: byEnvVar
-        versionEnvVar: RELEASE_VERSION
-        arguments: '--include-symbols'
-      env:
-        RELEASE_VERSION: $(releaseTag)
         DOTNET_CLI_TELEMETRY_OPTOUT: true
 
     - task: NuGetCommand@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ jobs:
         codeCoverageEnabled: true
 
     - task: DotNetCoreCLI@2
-      condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master')))
+      condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
       displayName: 'NuGet Pack (CI)'
       inputs:
         command: pack

--- a/src/TrueMyth/Maybe.cs
+++ b/src/TrueMyth/Maybe.cs
@@ -171,7 +171,7 @@ namespace TrueMyth
     ///   </code>
     /// </example>
     /// <typeparam name="TValue">Any type supported by the .NET type system.</typeparam>
-    public sealed class Maybe<TValue> : IComparable
+    public sealed class Maybe<TValue> : IComparable, IComparable<Maybe<TValue>>
     {
         #region Private Fields
 
@@ -402,19 +402,12 @@ namespace TrueMyth
         #region IComparable implementation
 
         /// <exclude/>
-        public int CompareTo(object obj)
+        public int CompareTo(Maybe<TValue> otherMaybe)
         {
-            if (obj == null) 
+            if (otherMaybe == null) 
             {
                 return 1;
             }
-
-            if (GetType() != obj.GetType())
-            {
-                throw new ArgumentException($"Parameter of different type: {obj.GetType()}", nameof(obj));
-            }
-
-            var otherMaybe = obj as Maybe<TValue>;
 
             if (object.ReferenceEquals(this, otherMaybe))
             {
@@ -445,6 +438,17 @@ namespace TrueMyth
                     }
                 }
             }
+        }
+
+        /// <exclude/>
+        public int CompareTo(object obj)
+        {
+            if (GetType() != obj.GetType())
+            {
+                throw new ArgumentException($"Parameter of different type: {obj.GetType()}", nameof(obj));
+            }
+
+            return CompareTo((Maybe<TValue>)obj);
         }
 
         #endregion

--- a/src/TrueMyth/Maybe.cs
+++ b/src/TrueMyth/Maybe.cs
@@ -171,7 +171,7 @@ namespace TrueMyth
     ///   </code>
     /// </example>
     /// <typeparam name="TValue">Any type supported by the .NET type system.</typeparam>
-    public sealed class Maybe<TValue>
+    public sealed class Maybe<TValue> : IComparable
     {
         #region Private Fields
 
@@ -394,6 +394,56 @@ namespace TrueMyth
                     hash = hash * prime + this._value.GetHashCode();
                 }
                 return hash;
+            }
+        }
+
+        #endregion
+
+        #region IComparable implementation
+
+        /// <exclude/>
+        public int CompareTo(object obj)
+        {
+            if (obj == null) 
+            {
+                return 1;
+            }
+
+            if (GetType() != obj.GetType())
+            {
+                throw new ArgumentException($"Parameter of different type: {obj.GetType()}", nameof(obj));
+            }
+
+            var otherMaybe = obj as Maybe<TValue>;
+
+            if (object.ReferenceEquals(this, otherMaybe))
+            {
+                return 0;
+            }
+
+            if (this.IsNothing)
+            {
+                return otherMaybe.IsJust ? -1 : 0;
+            } 
+            else
+            {
+                if (otherMaybe.IsNothing)
+                {
+                    return 1;
+                }
+                else
+                {
+                    if (typeof(IComparable).IsAssignableFrom(typeof(TValue)))
+                    {
+                        var justThis = UnsafelyUnwrap() as IComparable;
+                        var justThat = otherMaybe.UnsafelyUnwrap();
+                        return justThis.CompareTo(justThat);
+                    }
+                    else
+                    {
+                        return 0;
+                    }
+                }
             }
         }
 

--- a/src/TrueMyth/Result.cs
+++ b/src/TrueMyth/Result.cs
@@ -210,7 +210,7 @@ namespace TrueMyth
     /// <typeparam name="TValue">The value type for **Ok** values.</typeparam>
     /// <typeparam name="TError">The value type for **Err** values.</typeparam>
     
-    public sealed class Result<TValue, TError> : IComparable
+    public sealed class Result<TValue, TError> : IComparable, IComparable<Result<TValue,TError>>
     {
         #region Private Fields
 
@@ -544,19 +544,12 @@ namespace TrueMyth
         #region IComparable Implementation
         
         /// <exclude/>
-        public int CompareTo(object obj)
+        public int CompareTo(Result<TValue,TError> otherResult)
         {
-            if (obj == null)
+            if (otherResult == null)
             {
                 return 1;
             }
-
-            if (GetType() != obj.GetType())
-            {
-                throw new ArgumentException($"Parameter of different type: {obj.GetType()}", nameof(obj));
-            }
-
-            var otherResult = obj as Result<TValue, TError>;
 
             if (object.ReferenceEquals(this, otherResult))
             {
@@ -580,6 +573,34 @@ namespace TrueMyth
                     return 0;
                 }
             }
+            else
+            {
+                if (otherResult.IsErr)
+                {
+                    return 1;
+                }
+                else if (typeof(IComparable).IsAssignableFrom(typeof(TValue)))
+                {
+                    var thisValue = UnsafelyUnwrap() as IComparable;
+                    var thatValue = otherResult.UnsafelyUnwrap();
+                    return thisValue.CompareTo(thatValue);
+                }
+                else
+                {
+                    return 0;
+                }
+            }
+        }
+
+        /// <exclude/>
+        public int CompareTo(object obj)
+        {
+            if (GetType() != obj.GetType())
+            {
+                throw new ArgumentException($"Parameter of different type: {obj.GetType()}", nameof(obj));
+            }
+
+            return CompareTo((Result<TValue,TError>)obj);
         }
 
         #endregion

--- a/src/TrueMyth/Result.cs
+++ b/src/TrueMyth/Result.cs
@@ -210,7 +210,7 @@ namespace TrueMyth
     /// <typeparam name="TValue">The value type for **Ok** values.</typeparam>
     /// <typeparam name="TError">The value type for **Err** values.</typeparam>
     
-    public sealed class Result<TValue, TError>
+    public sealed class Result<TValue, TError> : IComparable
     {
         #region Private Fields
 
@@ -536,6 +536,49 @@ namespace TrueMyth
                     hash = hash + prime + this._error.GetHashCode();
                 }
                 return hash;
+            }
+        }
+
+        #endregion
+
+        #region IComparable Implementation
+        
+        /// <exclude/>
+        public int CompareTo(object obj)
+        {
+            if (obj == null)
+            {
+                return 1;
+            }
+
+            if (GetType() != obj.GetType())
+            {
+                throw new ArgumentException($"Parameter of different type: {obj.GetType()}", nameof(obj));
+            }
+
+            var otherResult = obj as Result<TValue, TError>;
+
+            if (object.ReferenceEquals(this, otherResult))
+            {
+                return 0;
+            }
+
+            if (this.IsErr)
+            {
+                if (otherResult.IsOk)
+                {
+                    return -1;
+                }
+                else if(typeof(IComparable).IsAssignableFrom(typeof(TError)))
+                {
+                    var thisErr = UnsafelyUnwrapErr() as IComparable;
+                    var thatErr = otherResult.UnsafelyUnwrapErr();
+                    return thisErr.CompareTo(thatErr);
+                }
+                else
+                {
+                    return 0;
+                }
             }
         }
 

--- a/test/TrueMyth.Test/MaybeTests.cs
+++ b/test/TrueMyth.Test/MaybeTests.cs
@@ -362,5 +362,131 @@ namespace TrueMyth.Test
             Assert.True(maybeList.IsNothing);
             Assert.False(maybeList.IsJust);
         }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IComparable_AtoA_Zero(bool useGenerics)
+        {
+            // arrange
+            var a = Maybe<int>.Of(0);
+            var a_obj = (object)a;
+            
+            // act
+            var result = useGenerics
+                ? a.CompareTo(a)
+                : a.CompareTo(a_obj);
+
+            // assert
+            Assert.Equal(0, result);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IComparable_Symmetry_Ok(bool useGenerics)
+        {
+            // arrange
+            var a = Maybe<int>.Of(0);
+            var a_obj = (object)a;
+            var b = Maybe<int>.Of(0);
+            var b_obj = (object)b;
+            
+            // act
+            var abResult = useGenerics
+                ? a.CompareTo(b)
+                : a.CompareTo(b_obj);
+            var baResult = useGenerics
+                ? b.CompareTo(a)
+                : b.CompareTo(a_obj);
+
+            // assert
+            Assert.Equal(0, abResult);
+            Assert.Equal(0, baResult);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IComparable_Transitive_Ok(bool useGenerics)
+        {
+            // arrange
+            var a = Maybe<int>.Of(0);
+            var a_obj = (object)a;
+            var b = Maybe<int>.Of(0);
+            var b_obj = (object)b;
+            var c = Maybe<int>.Of(0);
+            var c_obj = (object)c;
+            
+            // act
+            var abResult = useGenerics
+                ? a.CompareTo(b)
+                : a.CompareTo(b_obj);
+            var baResult = useGenerics
+                ? b.CompareTo(a)
+                : b.CompareTo(a_obj);
+            var acResult = useGenerics
+                ? a.CompareTo(c)
+                : a.CompareTo(c_obj);
+
+            // assert
+            Assert.Equal(0, abResult);
+            Assert.Equal(0, baResult);
+            Assert.Equal(0, acResult);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IComparable_Inverse_Ok(bool useGenerics)
+        {
+            // arrange
+            var a = Maybe<int>.Of(0);
+            var a_obj = (object)a;
+            var b = Maybe<int>.Of(1);
+            var b_obj = (object)b;
+
+            // act
+            var abResult = useGenerics
+                ? a.CompareTo(b)
+                : a.CompareTo(b_obj);
+            var baResult = useGenerics
+                ? b.CompareTo(a)
+                : b.CompareTo(a_obj);
+
+            // assert
+            Assert.Equal(-1, abResult);
+            Assert.Equal(1, baResult);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IComparable_Inductive_Ok(bool useGenerics)
+        {
+            // arrange
+            var a = Maybe<int>.Of(0);
+            var a_obj = (object)a;
+            var b = Maybe<int>.Of(1);
+            var b_obj = (object)b;
+            var c = Maybe<int>.Of(2);
+            var c_obj = (object)c;
+
+            // act
+            var abResult = useGenerics
+                ? a.CompareTo(b)
+                : a.CompareTo(b_obj);
+            var bcResult = useGenerics
+                ? b.CompareTo(c)
+                : b.CompareTo(c_obj);
+            var acResult = useGenerics
+                ? a.CompareTo(c)
+                : a.CompareTo(c_obj);
+
+            // assert
+            Assert.Equal(-1, abResult);
+            Assert.Equal(-1, bcResult);
+            Assert.Equal(-1, acResult);
+        }
     }
 }

--- a/test/TrueMyth.Test/ResultTests.cs
+++ b/test/TrueMyth.Test/ResultTests.cs
@@ -443,5 +443,252 @@ namespace TrueMyth.Test
             // assert
             Assert.NotEqual(hc1, hc2);
         }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IComparable_Ok_AtoA_Zero(bool useGenerics)
+        {
+            // arrange
+            var a = SimpleResult.Ok(0);
+            var a_obj = (object)a;
+
+            // act
+            var result = useGenerics
+                ? a.CompareTo(a)
+                : a.CompareTo(a_obj);
+
+            // assert
+            Assert.Equal(0, result);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IComparable_Err_AtoA_Zero(bool useGenerics)
+        {
+            // arrange
+            var a = SimpleResult.Err("test");
+            var a_obj = (object)a;
+
+            // act
+            var result = useGenerics
+                ? a.CompareTo(a)
+                : a.CompareTo(a_obj);
+
+            // assert
+            Assert.Equal(0, result);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IComparable_Ok_Symmetry_Ok(bool useGenerics)
+        {
+            // arrange
+            var a = SimpleResult.Ok(0);
+            var a_obj = (object)a;
+            var b = SimpleResult.Ok(0);
+            var b_obj = (object)b;
+
+            // act
+            var abResult = useGenerics 
+                ? a.CompareTo(b) 
+                : a.CompareTo(b_obj);
+            var baResult = useGenerics 
+                ? b.CompareTo(a)
+                : b.CompareTo(a_obj);
+
+            // assert
+            Assert.Equal(0, abResult);
+            Assert.Equal(0, baResult);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IComparable_Err_Symmetry_Ok(bool useGenerics)
+        {
+            // arrange
+            var a = SimpleResult.Err("test");
+            var a_obj = (object)a;
+            var b = SimpleResult.Err("test");
+            var b_obj = (object)b;
+
+            // act
+            var abResult = useGenerics
+                ? a.CompareTo(b)
+                : a.CompareTo(b_obj);
+            var baResult = useGenerics
+                ? b.CompareTo(a)
+                : b.CompareTo(a_obj);
+
+            // assert
+            Assert.Equal(0, abResult);
+            Assert.Equal(0, baResult);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IComparable_Ok_Transitive_Ok(bool useGenerics)
+        {
+            // arrange
+            var a = SimpleResult.Ok(0);
+            var a_obj = (object)a;
+            var b = SimpleResult.Ok(0);
+            var b_obj = (object)b;
+            var c = SimpleResult.Ok(0);
+            var c_obj = (object)c;
+
+            // act
+            var abResult = useGenerics
+                ? a.CompareTo(b)
+                : a.CompareTo(b_obj);
+            var baResult = useGenerics
+                ? b.CompareTo(a)
+                : b.CompareTo(a_obj);
+            var acResult = useGenerics
+                ? a.CompareTo(c)
+                : a.CompareTo(c_obj);
+
+            // assert
+            Assert.Equal(0, abResult);
+            Assert.Equal(0, baResult);
+            Assert.Equal(0, acResult);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IComparable_Err_Transitive_Ok(bool useGenerics)
+        {
+            var a = SimpleResult.Err("test");
+            var b = SimpleResult.Err("test");
+            var c = SimpleResult.Err("test");
+            var a_obj = (object)a;
+            var b_obj = (object)b;
+            var c_obj = (object)c;
+
+            // act
+            var abResult = useGenerics
+                ? a.CompareTo(b)
+                : a.CompareTo(b_obj);
+            var baResult = useGenerics
+                ? b.CompareTo(a)
+                : b.CompareTo(a_obj);
+            var acResult = useGenerics
+                ? a.CompareTo(c)
+                : a.CompareTo(c_obj);
+
+            // assert
+            Assert.Equal(0, abResult);
+            Assert.Equal(0, baResult);
+            Assert.Equal(0, acResult);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IComparable_Ok_Inverse_Ok(bool useGenerics)
+        {
+            var a = SimpleResult.Ok(0);
+            var b = SimpleResult.Ok(1);
+            var a_obj = (object)a;
+            var b_obj = (object)b;
+
+            // act
+            var abResult = useGenerics
+                ? a.CompareTo(b)
+                : a.CompareTo(b_obj);
+            var baResult = useGenerics
+                ? b.CompareTo(a)
+                : b.CompareTo(a_obj);
+
+            // assert
+            Assert.Equal(-1, abResult);
+            Assert.Equal(1, baResult);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IComparable_Err_Inverse_Ok(bool useGenerics)
+        {
+            var a = SimpleResult.Err("test");
+            var b = SimpleResult.Err("xyz");
+            var a_obj = (object)a;
+            var b_obj = (object)b;
+
+            // act
+            var abResult = useGenerics
+                ? a.CompareTo(b)
+                : a.CompareTo(b_obj);
+            var baResult = useGenerics
+                ? b.CompareTo(a)
+                : b.CompareTo(a_obj);
+
+            // assert
+            Assert.Equal(-1, abResult);
+            Assert.Equal(1, baResult);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IComparable_Ok_Inductive_Ok(bool useGenerics)
+        {
+            var a = SimpleResult.Ok(0);
+            var b = SimpleResult.Ok(1);
+            var c = SimpleResult.Ok(2);
+            var a_obj = (object)a;
+            var b_obj = (object)b;
+            var c_obj = (object)c;
+
+            // act
+            var abResult = useGenerics
+                ? a.CompareTo(b)
+                : a.CompareTo(b_obj);
+            var bcResult = useGenerics
+                ? b.CompareTo(c)
+                : b.CompareTo(c_obj);
+            var acResult = useGenerics
+                ? a.CompareTo(c)
+                : a.CompareTo(c_obj);
+
+            // assert
+            Assert.Equal(-1, abResult);
+            Assert.Equal(-1, bcResult);
+            Assert.Equal(-1, acResult);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IComparable_Err_Inductive_Ok(bool useGenerics)
+        {
+            var a = SimpleResult.Ok(0);
+            var b = SimpleResult.Ok(1);
+            var c = SimpleResult.Ok(2);
+            var a_obj = (object)a;
+            var b_obj = (object)b;
+            var c_obj = (object)c;
+
+            // act
+            var abResult = useGenerics 
+                ? a.CompareTo(b)
+                : a.CompareTo(b_obj);
+            var bcResult = useGenerics
+                ? b.CompareTo(c)
+                : b.CompareTo(c_obj);
+            var acResult = useGenerics
+                ? a.CompareTo(c)
+                : a.CompareTo(c_obj);
+
+            // assert
+            Assert.Equal(-1, abResult);
+            Assert.Equal(-1, bcResult);
+            Assert.Equal(-1, acResult);
+        }
     }
 }


### PR DESCRIPTION
This addresses #22.  Both `IComparable` and `IComparable<T>` are implemented.  Main properties are tested, although there is room for more tests, particularly with mixed `Result`s.